### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,3 +254,8 @@ src/
 2. `json_filter` extracts relevant fields
 3. Process clean data without noise
 4. `json_schema` generates types for safety
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kehvinbehvin-json-mcp-filter).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/kehvinbehvin-json-mcp-filter)